### PR TITLE
Naive datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Improved error handling
  - Tighten up typing
  - Increased test coverage
+ - Fixed Postgresql issues with tz-aware datetimes (NaiveDatetime)
 
 ## [0.2.5] - 2025-05-28
  - 98% test coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Run E2E tests: `poetry run pytest -m e2e`
 - Format code: `poetry run ruff format .`
 - Check linting: `poetry run ruff check .`
+- Type checking: `poetry run pyright`
 - Complexity analysis: `poetry run radon cc luthien_control/ -a -s`
 - Use poetry run to run commands in the development environment
+
+## Quality Validation Before Committing
+Always run these commands before committing code:
+1. `poetry run ruff check --fix .` - Check linting
+2. `poetry run ruff format .` - Format code
+3. `poetry run pyright` - Check types
+4. `poetry run pytest --cov=luthien_control` - Run tests with coverage
 
 ## Code Style
 - Mandatory TDD workflow (skeleton → tests → implementation)
 - Python 3.11+, follow PEP 8
-- Line length: 120 characters
+- Max Line length: 120 characters
 - Use type hints for all function signatures
-- Prefer functional components over classes
 - Organize imports with standard order (typing first)
 - Use async functions for I/O-bound tasks
 - Error handling: Specific exception types, HTTPException for API errors
-- Naming: lowercase_with_underscores, descriptive with auxiliary verbs
-- Docstrings for modules, classes, and functions
+- Google-style docstrings for modules, classes, and functions

--- a/luthien_control/control_policy/tx_logging_policy.py
+++ b/luthien_control/control_policy/tx_logging_policy.py
@@ -61,7 +61,7 @@ class TxLoggingPolicy(ControlPolicy):
     ) -> TransactionContext:
         """Applies all configured logging specifications to the transaction context."""
 
-        current_dt = NaiveDatetime.now()  # Use NaiveDatetime exclusively
+        current_dt = NaiveDatetime.now()
         tx_id = str(context.transaction_id)
 
         try:

--- a/luthien_control/db/naive_datetime.py
+++ b/luthien_control/db/naive_datetime.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timezone, tzinfo
+from typing import Any, Optional
+
+from pydantic_core import core_schema
+
+
+class NaiveDatetime(datetime):
+    """A datetime that automatically strips timezone info."""
+
+    def __new__(cls, *args, **kwargs):
+        # Handle datetime object as first argument
+        if args and isinstance(args[0], datetime):
+            dt = args[0]
+            # Convert to naive UTC if timezone-aware, otherwise keep as-is
+            if dt.tzinfo is not None:
+                dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+            return super().__new__(cls, dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
+        else:
+            # Normal datetime constructor
+            return super().__new__(cls, *args, **kwargs)
+
+    @classmethod
+    def now(cls, tz: Optional[tzinfo] = None) -> "NaiveDatetime":
+        """Create a NaiveDatetime representing the current UTC time (naive)."""
+        # Always return naive UTC time regardless of tz parameter for consistency
+        return cls(datetime.now(timezone.utc))
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> core_schema.CoreSchema:
+        """Pydantic schema for NaiveDatetime."""
+        return core_schema.with_info_before_validator_function(
+            cls._convert_to_naive,
+            core_schema.datetime_schema(),
+        )
+
+    @classmethod
+    def _convert_to_naive(cls, value: Any, info: Any) -> Any:
+        """Convert datetime to naive before Pydantic processes it."""
+        if isinstance(value, datetime):
+            return cls(value)  # This will trigger our __new__ method
+        return value  # Let Pydantic handle other types

--- a/luthien_control/db/sqlmodel_models.py
+++ b/luthien_control/db/sqlmodel_models.py
@@ -1,50 +1,13 @@
 import datetime as dt
-from datetime import datetime, timezone, tzinfo
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from pydantic import model_validator
-from pydantic_core import core_schema
 from sqlalchemy import JSON, Column, String, types
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
 
-
-class NaiveDatetime(datetime):
-    """A datetime that automatically strips timezone info."""
-
-    def __new__(cls, *args, **kwargs):
-        # Handle datetime object as first argument
-        if args and isinstance(args[0], datetime):
-            dt = args[0]
-            # Convert to naive UTC if timezone-aware, otherwise keep as-is
-            if dt.tzinfo is not None:
-                dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
-            return super().__new__(cls, dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
-        else:
-            # Normal datetime constructor
-            return super().__new__(cls, *args, **kwargs)
-
-    @classmethod
-    def now(cls, tz: Optional[tzinfo] = None) -> "NaiveDatetime":
-        """Create a NaiveDatetime representing the current UTC time (naive)."""
-        # Always return naive UTC time regardless of tz parameter for consistency
-        return cls(datetime.now(timezone.utc))
-
-    @classmethod
-    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> core_schema.CoreSchema:
-        """Pydantic schema for NaiveDatetime."""
-        return core_schema.with_info_before_validator_function(
-            cls._convert_to_naive,
-            core_schema.datetime_schema(),
-        )
-
-    @classmethod
-    def _convert_to_naive(cls, value: Any, info: Any) -> Any:
-        """Convert datetime to naive before Pydantic processes it."""
-        if isinstance(value, datetime):
-            return cls(value)  # This will trigger our __new__ method
-        return value  # Let Pydantic handle other types
-
+from .naive_datetime import NaiveDatetime
 
 # SQLModel models combining SQLAlchemy and Pydantic
 
@@ -136,9 +99,9 @@ class LuthienLog(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True, index=True)
     transaction_id: str = Field(index=True, nullable=False)
     datetime: NaiveDatetime = Field(
-        default_factory=NaiveDatetime.now,  # Use the class method consistently
+        default_factory=NaiveDatetime.now,
         nullable=False,
-        index=True,  # Add index directly here
+        index=True,
     )
     data: Optional[dict[str, Any]] = Field(default=None, sa_column=Column(JsonBOrJson))
     datatype: str = Field(index=True, nullable=False)

--- a/luthien_control/db/sqlmodel_models.py
+++ b/luthien_control/db/sqlmodel_models.py
@@ -1,11 +1,50 @@
 import datetime as dt
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from typing import Any, Dict, Optional
 
 from pydantic import model_validator
+from pydantic_core import core_schema
 from sqlalchemy import JSON, Column, String, types
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
+
+
+class NaiveDatetime(datetime):
+    """A datetime that automatically strips timezone info."""
+
+    def __new__(cls, *args, **kwargs):
+        # Handle datetime object as first argument
+        if args and isinstance(args[0], datetime):
+            dt = args[0]
+            # Convert to naive UTC if timezone-aware, otherwise keep as-is
+            if dt.tzinfo is not None:
+                dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+            return super().__new__(cls, dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
+        else:
+            # Normal datetime constructor
+            return super().__new__(cls, *args, **kwargs)
+
+    @classmethod
+    def now(cls, tz: Optional[tzinfo] = None) -> "NaiveDatetime":
+        """Create a NaiveDatetime representing the current UTC time (naive)."""
+        # Always return naive UTC time regardless of tz parameter for consistency
+        return cls(datetime.now(timezone.utc))
+
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type: Any, handler: Any) -> core_schema.CoreSchema:
+        """Pydantic schema for NaiveDatetime."""
+        return core_schema.with_info_before_validator_function(
+            cls._convert_to_naive,
+            core_schema.datetime_schema(),
+        )
+
+    @classmethod
+    def _convert_to_naive(cls, value: Any, info: Any) -> Any:
+        """Convert datetime to naive before Pydantic processes it."""
+        if isinstance(value, datetime):
+            return cls(value)  # This will trigger our __new__ method
+        return value  # Let Pydantic handle other types
+
 
 # SQLModel models combining SQLAlchemy and Pydantic
 
@@ -94,18 +133,24 @@ class LuthienLog(SQLModel, table=True):
         notes: JSON blob for additional contextual information.
     """
 
-    # __tablename__ = "luthien_log" # SQLModel infers this or use class Config
-
     id: Optional[int] = Field(default=None, primary_key=True, index=True)
     transaction_id: str = Field(index=True, nullable=False)
-    datetime: dt.datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc),  # Store as UTC
+    datetime: NaiveDatetime = Field(
+        default_factory=NaiveDatetime.now,  # Use the class method consistently
         nullable=False,
         index=True,  # Add index directly here
     )
     data: Optional[dict[str, Any]] = Field(default=None, sa_column=Column(JsonBOrJson))
     datatype: str = Field(index=True, nullable=False)
     notes: Optional[dict[str, Any]] = Field(default=None, sa_column=Column(JsonBOrJson))
+
+    def __init__(self, **data: Any) -> None:
+        """Override init to ensure datetime is converted to NaiveDatetime."""
+        if "datetime" in data:
+            dt_value = data["datetime"]
+            if isinstance(dt_value, datetime) and not isinstance(dt_value, NaiveDatetime):
+                data["datetime"] = NaiveDatetime(dt_value)
+        super().__init__(**data)
 
     # __table_args__ = (
     #     Index("ix_sqlmodel_luthien_log_transaction_id", "transaction_id"),

--- a/tests/control_policy/test_tx_logging_policy.py
+++ b/tests/control_policy/test_tx_logging_policy.py
@@ -1,5 +1,4 @@
 import logging  # For caplog
-from datetime import datetime, timezone
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock  # For mocking async session and spec methods
 
@@ -13,7 +12,7 @@ from luthien_control.control_policy.tx_logging.tx_logging_spec import (
 from luthien_control.control_policy.tx_logging_policy import TxLoggingPolicy
 from luthien_control.core.dependency_container import DependencyContainer
 from luthien_control.core.transaction_context import TransactionContext
-from luthien_control.db.sqlmodel_models import LuthienLog
+from luthien_control.db.sqlmodel_models import LuthienLog, NaiveDatetime
 
 # --- Test Fixtures and Mocks ---
 
@@ -106,7 +105,7 @@ async def test_log_database_entry(mock_async_session: AsyncMock):
     """Test the _log_database_entry helper method."""
     policy = TxLoggingPolicy(spec=MockTxLoggingSpec())  # Spec doesn't matter here
     tx_id = "tx-log-entry-test"
-    dt = datetime.now(timezone.utc)
+    dt = NaiveDatetime.now()
     log_data = LuthienLogData(
         datatype="test_dt", data=SerializableDict({"key": "val"}), notes=SerializableDict({"n": "v"})
     )

--- a/tests/db/test_naive_datetime.py
+++ b/tests/db/test_naive_datetime.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timedelta, timezone
+
+from luthien_control.db.naive_datetime import NaiveDatetime
+
+
+def test_naive_datetime_strips_timezone():
+    """Test that NaiveDatetime automatically strips timezone info."""
+    # Test with timezone-aware datetime
+    aware_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    naive_dt = NaiveDatetime(aware_dt)
+
+    assert naive_dt.tzinfo is None
+    assert naive_dt.year == 2023
+    assert naive_dt.month == 1
+    assert naive_dt.day == 1
+    assert naive_dt.hour == 12
+
+
+def test_naive_datetime_preserves_naive():
+    """Test that NaiveDatetime preserves already-naive datetimes."""
+    # Test with already-naive datetime
+    original_naive = datetime(2023, 1, 1, 12, 0, 0)
+    naive_dt = NaiveDatetime(original_naive)
+
+    assert naive_dt.tzinfo is None
+    assert naive_dt == original_naive
+
+
+def test_naive_datetime_converts_non_utc_timezone():
+    """Test that NaiveDatetime converts non-UTC timezones to naive UTC."""
+    # Create a timezone-aware datetime in EST (UTC-5)
+    est = timezone(timedelta(hours=-5))
+    est_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=est)  # 12 PM EST = 5 PM UTC
+
+    naive_dt = NaiveDatetime(est_dt)
+
+    assert naive_dt.tzinfo is None
+    assert naive_dt.hour == 17  # Should be converted to 5 PM UTC
+
+
+def test_naive_datetime_normal_constructor():
+    """Test that NaiveDatetime works with normal datetime constructor arguments."""
+    naive_dt = NaiveDatetime(2023, 1, 1, 12, 0, 0)
+
+    assert naive_dt.tzinfo is None
+    assert naive_dt.year == 2023
+    assert naive_dt.month == 1
+    assert naive_dt.day == 1
+    assert naive_dt.hour == 12
+
+
+def test_naive_datetime_now():
+    """Test that NaiveDatetime.now() returns current naive UTC time."""
+    before = NaiveDatetime.now()
+    naive_now = NaiveDatetime.now()
+    after = NaiveDatetime.now()
+
+    # Should be naive
+    assert naive_now.tzinfo is None
+
+    # Should be close to current time (within 1 second)
+    assert before <= naive_now <= after or abs((naive_now - before).total_seconds()) < 1
+    assert isinstance(naive_now, NaiveDatetime)
+
+
+def test_tx_logging_policy_datetime_handling():
+    """Test that demonstrates our solution prevents the original timezone issue."""
+    # Simulate what TxLoggingPolicy does now - creates timezone-aware datetime
+    # but converts it to naive before passing to LuthienLog
+    timezone_aware_dt = datetime.now(timezone.utc)
+
+    # Our fix: use NaiveDatetime constructor to strip timezone
+    naive_dt = NaiveDatetime(timezone_aware_dt)
+
+    # Verify it's properly converted
+    assert naive_dt.tzinfo is None
+    assert isinstance(naive_dt, NaiveDatetime)

--- a/tests/db/test_naive_datetime.py
+++ b/tests/db/test_naive_datetime.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from luthien_control.db.naive_datetime import NaiveDatetime
+from pydantic import BaseModel
 
 
 def test_naive_datetime_strips_timezone():
@@ -75,3 +77,53 @@ def test_tx_logging_policy_datetime_handling():
     # Verify it's properly converted
     assert naive_dt.tzinfo is None
     assert isinstance(naive_dt, NaiveDatetime)
+
+
+def test_pydantic_core_schema():
+    """Test the Pydantic core schema generation."""
+    schema = NaiveDatetime.__get_pydantic_core_schema__(Any, lambda x: x)
+    assert isinstance(schema, dict)
+    assert "type" in schema
+
+
+def test_pydantic_convert_to_naive_with_datetime():
+    """Test the _convert_to_naive method with datetime input."""
+    aware_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    result = NaiveDatetime._convert_to_naive(aware_dt, None)
+
+    assert isinstance(result, NaiveDatetime)
+    assert result.tzinfo is None
+
+
+def test_pydantic_convert_to_naive_with_non_datetime():
+    """Test the _convert_to_naive method with non-datetime input."""
+    # Test with string - should pass through unchanged
+    string_value = "2023-01-01T12:00:00"
+    result = NaiveDatetime._convert_to_naive(string_value, None)
+    assert result == string_value
+
+    # Test with integer - should pass through unchanged
+    int_value = 12345
+    result = NaiveDatetime._convert_to_naive(int_value, None)
+    assert result == int_value
+
+
+def test_pydantic_integration():
+    """Test NaiveDatetime integration with Pydantic models."""
+
+    class TestModel(BaseModel):
+        dt: NaiveDatetime
+
+    # Test with timezone-aware datetime
+    aware_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    model = TestModel(dt=aware_dt)  # type: ignore[arg-type]
+
+    assert isinstance(model.dt, NaiveDatetime)
+    assert model.dt.tzinfo is None
+
+    # Test with naive datetime
+    naive_dt = datetime(2023, 1, 1, 12, 0, 0)
+    model2 = TestModel(dt=naive_dt)  # type: ignore[arg-type]
+
+    assert isinstance(model2.dt, NaiveDatetime)
+    assert model2.dt.tzinfo is None

--- a/tests/db/test_sqlmodel_models.py
+++ b/tests/db/test_sqlmodel_models.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta, timezone
 
+from luthien_control.db.naive_datetime import NaiveDatetime
 from luthien_control.db.sqlmodel_models import (
     ClientApiKey,
     ControlPolicy,
     LuthienLog,
-    NaiveDatetime,
 )
 
 
@@ -165,7 +165,7 @@ def test_client_api_key_creation_all_fields():
 
 def test_luthien_log_creation_required_fields():
     """Test successful creation of LuthienLog with required fields."""
-    now_utc = NaiveDatetime.now()  # Use NaiveDatetime
+    now_utc = NaiveDatetime.now()
     log = LuthienLog(transaction_id="tx-abc-123", datatype="test_event")
 
     assert log.id is None
@@ -180,7 +180,7 @@ def test_luthien_log_creation_required_fields():
 
 def test_luthien_log_creation_all_fields():
     """Test successful creation of LuthienLog with all fields specified."""
-    log_time = NaiveDatetime(2023, 6, 15, 14, 30, 0)  # Use NaiveDatetime
+    log_time = NaiveDatetime(2023, 6, 15, 14, 30, 0)
     log_data_content = {"event_details": "something happened"}
     log_notes_content = {"source": "test_suite"}
 
@@ -203,48 +203,11 @@ def test_luthien_log_creation_all_fields():
 
 def test_luthien_log_repr():
     """Test the __repr__ method of LuthienLog."""
-    log_time = NaiveDatetime(2023, 1, 1, 0, 0, 0)  # Use NaiveDatetime
+    log_time = NaiveDatetime(2023, 1, 1, 0, 0, 0)
     log = LuthienLog(id=1, transaction_id="repr-tx", datetime=log_time, datatype="repr_test")
     # No timezone in repr
     expected_repr = "<LuthienLog(id=1, transaction_id='repr-tx', datetime='2023-01-01 00:00:00', datatype='repr_test')>"
     assert repr(log) == expected_repr
-
-
-def test_naive_datetime_strips_timezone():
-    """Test that NaiveDatetime automatically strips timezone info."""
-    # Test with timezone-aware datetime
-    aware_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-    naive_dt = NaiveDatetime(aware_dt)
-
-    assert naive_dt.tzinfo is None
-    assert naive_dt.year == 2023
-    assert naive_dt.month == 1
-    assert naive_dt.day == 1
-    assert naive_dt.hour == 12
-
-
-def test_naive_datetime_preserves_naive():
-    """Test that NaiveDatetime preserves already-naive datetimes."""
-    # Test with already-naive datetime
-    original_naive = datetime(2023, 1, 1, 12, 0, 0)
-    naive_dt = NaiveDatetime(original_naive)
-
-    assert naive_dt.tzinfo is None
-    assert naive_dt == original_naive
-
-
-def test_naive_datetime_converts_non_utc_timezone():
-    """Test that NaiveDatetime converts non-UTC timezones to naive UTC."""
-    from datetime import timedelta
-
-    # Create a timezone-aware datetime in EST (UTC-5)
-    est = timezone(timedelta(hours=-5))
-    est_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=est)  # 12 PM EST = 5 PM UTC
-
-    naive_dt = NaiveDatetime(est_dt)
-
-    assert naive_dt.tzinfo is None
-    assert naive_dt.hour == 17  # Should be converted to 5 PM UTC
 
 
 def test_luthien_log_with_timezone_aware_datetime():
@@ -264,60 +227,3 @@ def test_luthien_log_with_timezone_aware_datetime():
     assert log.datetime.month == 6
     assert log.datetime.day == 15
     assert log.datetime.hour == 14  # Should preserve the UTC time
-
-
-def test_naive_datetime_normal_constructor():
-    """Test that NaiveDatetime works with normal datetime constructor arguments."""
-    naive_dt = NaiveDatetime(2023, 1, 1, 12, 0, 0)
-
-    assert naive_dt.tzinfo is None
-    assert naive_dt.year == 2023
-    assert naive_dt.month == 1
-    assert naive_dt.day == 1
-    assert naive_dt.hour == 12
-
-
-def test_tx_logging_policy_datetime_handling():
-    """Test that demonstrates our solution prevents the original timezone issue."""
-    from datetime import datetime, timezone
-
-    from luthien_control.db.sqlmodel_models import NaiveDatetime
-
-    # Simulate what TxLoggingPolicy does now - creates timezone-aware datetime
-    # but converts it to naive before passing to LuthienLog
-    timezone_aware_dt = datetime.now(timezone.utc)
-
-    # Our fix: use NaiveDatetime constructor to strip timezone
-    naive_dt = NaiveDatetime(timezone_aware_dt)
-
-    # Verify it's properly converted
-    assert naive_dt.tzinfo is None
-    assert isinstance(naive_dt, NaiveDatetime)
-
-    # This naive datetime can now be safely used in LuthienLog
-    log = LuthienLog(
-        transaction_id="tx-policy-test",
-        datatype="policy_test_event",
-        datetime=naive_dt,
-    )
-
-    # The datetime should be naive and safe for database insertion
-    assert log.datetime.tzinfo is None
-    assert log.datetime.year == timezone_aware_dt.year
-    assert log.datetime.month == timezone_aware_dt.month
-    assert log.datetime.day == timezone_aware_dt.day
-
-
-def test_naive_datetime_now():
-    """Test that NaiveDatetime.now() returns current naive UTC time."""
-
-    before = NaiveDatetime.now()
-    naive_now = NaiveDatetime.now()
-    after = NaiveDatetime.now()
-
-    # Should be naive
-    assert naive_now.tzinfo is None
-
-    # Should be close to current time (within 1 second)
-    assert before <= naive_now <= after or abs((naive_now - before).total_seconds()) < 1
-    assert isinstance(naive_now, NaiveDatetime)

--- a/tests/db/test_sqlmodel_models.py
+++ b/tests/db/test_sqlmodel_models.py
@@ -1,6 +1,11 @@
 from datetime import datetime, timedelta, timezone
 
-from luthien_control.db.sqlmodel_models import ClientApiKey, ControlPolicy, LuthienLog
+from luthien_control.db.sqlmodel_models import (
+    ClientApiKey,
+    ControlPolicy,
+    LuthienLog,
+    NaiveDatetime,
+)
 
 
 def test_policy_creation():
@@ -160,22 +165,22 @@ def test_client_api_key_creation_all_fields():
 
 def test_luthien_log_creation_required_fields():
     """Test successful creation of LuthienLog with required fields."""
-    now_utc = datetime.now(timezone.utc)
+    now_utc = NaiveDatetime.now()  # Use NaiveDatetime
     log = LuthienLog(transaction_id="tx-abc-123", datatype="test_event")
 
     assert log.id is None
     assert log.transaction_id == "tx-abc-123"
     assert log.datatype == "test_event"
     assert isinstance(log.datetime, datetime)
-    assert log.datetime.tzinfo == timezone.utc
-    assert abs(log.datetime - now_utc) < timedelta(seconds=1)
+    assert log.datetime.tzinfo is None  # Should be naive datetime
+    assert abs((log.datetime - now_utc).total_seconds()) < 1
     assert log.data is None
     assert log.notes is None
 
 
 def test_luthien_log_creation_all_fields():
     """Test successful creation of LuthienLog with all fields specified."""
-    log_time = datetime(2023, 6, 15, 14, 30, 0, tzinfo=timezone.utc)
+    log_time = NaiveDatetime(2023, 6, 15, 14, 30, 0)  # Use NaiveDatetime
     log_data_content = {"event_details": "something happened"}
     log_notes_content = {"source": "test_suite"}
 
@@ -198,9 +203,121 @@ def test_luthien_log_creation_all_fields():
 
 def test_luthien_log_repr():
     """Test the __repr__ method of LuthienLog."""
-    log_time = datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    log_time = NaiveDatetime(2023, 1, 1, 0, 0, 0)  # Use NaiveDatetime
     log = LuthienLog(id=1, transaction_id="repr-tx", datetime=log_time, datatype="repr_test")
-    expected_repr = (
-        "<LuthienLog(id=1, transaction_id='repr-tx', datetime='2023-01-01 00:00:00+00:00', datatype='repr_test')>"
-    )
+    # No timezone in repr
+    expected_repr = "<LuthienLog(id=1, transaction_id='repr-tx', datetime='2023-01-01 00:00:00', datatype='repr_test')>"
     assert repr(log) == expected_repr
+
+
+def test_naive_datetime_strips_timezone():
+    """Test that NaiveDatetime automatically strips timezone info."""
+    # Test with timezone-aware datetime
+    aware_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    naive_dt = NaiveDatetime(aware_dt)
+
+    assert naive_dt.tzinfo is None
+    assert naive_dt.year == 2023
+    assert naive_dt.month == 1
+    assert naive_dt.day == 1
+    assert naive_dt.hour == 12
+
+
+def test_naive_datetime_preserves_naive():
+    """Test that NaiveDatetime preserves already-naive datetimes."""
+    # Test with already-naive datetime
+    original_naive = datetime(2023, 1, 1, 12, 0, 0)
+    naive_dt = NaiveDatetime(original_naive)
+
+    assert naive_dt.tzinfo is None
+    assert naive_dt == original_naive
+
+
+def test_naive_datetime_converts_non_utc_timezone():
+    """Test that NaiveDatetime converts non-UTC timezones to naive UTC."""
+    from datetime import timedelta
+
+    # Create a timezone-aware datetime in EST (UTC-5)
+    est = timezone(timedelta(hours=-5))
+    est_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=est)  # 12 PM EST = 5 PM UTC
+
+    naive_dt = NaiveDatetime(est_dt)
+
+    assert naive_dt.tzinfo is None
+    assert naive_dt.hour == 17  # Should be converted to 5 PM UTC
+
+
+def test_luthien_log_with_timezone_aware_datetime():
+    """Test that LuthienLog automatically converts timezone-aware datetimes to naive."""
+    # This test demonstrates how our NaiveDatetime class prevents the original timezone issue
+    timezone_aware_dt = datetime(2023, 6, 15, 14, 30, 0, tzinfo=timezone.utc)
+
+    log = LuthienLog(
+        transaction_id="tx-timezone-test",
+        datatype="timezone_test_event",
+        datetime=timezone_aware_dt,  # Pass timezone-aware datetime  # type: ignore[arg-type]
+    )
+
+    # The datetime should be automatically converted to naive
+    assert log.datetime.tzinfo is None
+    assert log.datetime.year == 2023
+    assert log.datetime.month == 6
+    assert log.datetime.day == 15
+    assert log.datetime.hour == 14  # Should preserve the UTC time
+
+
+def test_naive_datetime_normal_constructor():
+    """Test that NaiveDatetime works with normal datetime constructor arguments."""
+    naive_dt = NaiveDatetime(2023, 1, 1, 12, 0, 0)
+
+    assert naive_dt.tzinfo is None
+    assert naive_dt.year == 2023
+    assert naive_dt.month == 1
+    assert naive_dt.day == 1
+    assert naive_dt.hour == 12
+
+
+def test_tx_logging_policy_datetime_handling():
+    """Test that demonstrates our solution prevents the original timezone issue."""
+    from datetime import datetime, timezone
+
+    from luthien_control.db.sqlmodel_models import NaiveDatetime
+
+    # Simulate what TxLoggingPolicy does now - creates timezone-aware datetime
+    # but converts it to naive before passing to LuthienLog
+    timezone_aware_dt = datetime.now(timezone.utc)
+
+    # Our fix: use NaiveDatetime constructor to strip timezone
+    naive_dt = NaiveDatetime(timezone_aware_dt)
+
+    # Verify it's properly converted
+    assert naive_dt.tzinfo is None
+    assert isinstance(naive_dt, NaiveDatetime)
+
+    # This naive datetime can now be safely used in LuthienLog
+    log = LuthienLog(
+        transaction_id="tx-policy-test",
+        datatype="policy_test_event",
+        datetime=naive_dt,
+    )
+
+    # The datetime should be naive and safe for database insertion
+    assert log.datetime.tzinfo is None
+    assert log.datetime.year == timezone_aware_dt.year
+    assert log.datetime.month == timezone_aware_dt.month
+    assert log.datetime.day == timezone_aware_dt.day
+
+
+def test_naive_datetime_now():
+    """Test that NaiveDatetime.now() returns current naive UTC time."""
+
+    before = NaiveDatetime.now()
+    naive_now = NaiveDatetime.now()
+    after = NaiveDatetime.now()
+
+    # Should be naive
+    assert naive_now.tzinfo is None
+
+    # Should be close to current time (within 1 second)
+    assert before <= naive_now <= after or abs((naive_now - before).total_seconds()) < 1
+    assert isinstance(naive_now, NaiveDatetime)


### PR DESCRIPTION
tz-aware datetimes break postgresql with the current schema, and this wasn't caught through static analysis, which annoys me. So: adding a NaiveDatetime type and using it everywhere.